### PR TITLE
Added Memo support to assign recipients

### DIFF
--- a/src/Model/Memo.php
+++ b/src/Model/Memo.php
@@ -2,6 +2,8 @@
 
 namespace CommunityDS\Deputy\Api\Model;
 
+use CommunityDS\Deputy\Api\InvalidParamException;
+use CommunityDS\Deputy\Api\NotSupportedException;
 use DateTime;
 
 /**
@@ -28,7 +30,17 @@ use DateTime;
  */
 class Memo extends Record
 {
-
+    
+    /**
+     * @var integer[] User recipients of this Memo
+     */
+    private $assignedUserIds = [];
+    
+    /**
+     * @var integer[] Company recipients of this Memo
+     */
+    private $assignedCompanyIds = [];
+    
     /**
      * Returns the title.
      *
@@ -37,5 +49,128 @@ class Memo extends Record
     public function getDisplayName()
     {
         return $this->title;
+    }
+    
+    
+    /**
+     * Creates new Memo resource via the POST /supervise/memo endpoint,
+     * and then sends any remaining attributes to POST /resource/Memo/:id endpoint.
+     *
+     * @param string[] $attributeNames Names of attributes to store; or null to use only populated attributes.
+     *
+     * @return boolean
+     *
+     * @throws InvalidParamException When current instance already has a primary key
+     */
+    public function insert($attributeNames = null)
+    {
+        return $this->postSuperviseMemo(
+            $this->insertPayload($attributeNames)
+        );
+    }
+    
+    /**
+     * Sends a payload to the POST /supervise/memo endpoint
+     * and then sends remaining payload to POST /resource/Memo/:id endpoint.
+     *
+     * @param array $original Original payload
+     *
+     * @return boolean
+     *
+     * @throws NotSupportedException When attempting to update existing record
+     */
+    protected function postSuperviseMemo($original)
+    {
+        
+        $payload = [];
+        if ($this->getPrimaryKey()) {
+            throw new NotSupportedException('postSuperviseMemo does not support updating Memo');
+        } else {
+            $payload['arrAssignedCompanyIds']   = $this->assignedCompanyIds;
+            $payload['arrAssignedUserIds']      = $this->assignedUserIds;
+        }
+        
+        foreach ($original as $name => $value) {
+            switch ($name) {
+                case 'Content':
+                    $payload['strContent'] = $value;
+                    unset($original[$name]);
+                    break;
+                case 'Company':
+                    $payload['intCompany'] = $value;
+                    unset($original[$name]);
+                    break;
+                case 'File':
+                    $payload['arrFileIds'] = [$value];
+                    unset($original[$name]);
+                    break;
+            }
+        }
+        
+        $response = $this->getWrapper()->client->post(
+            'supervise/memo',
+            $payload
+        );
+        if ($response === false) {
+            $this->setErrorsFromResponse($this->getWrapper()->client->getLastError());
+            return false;
+        }
+        
+        static::populateRecord($this, $response);
+        
+        // Determine additional fields that the supervise/memo endpoint
+        // does not support and if any are found then change their value
+        // within the model and force an update.
+        
+        $updateRecord = false;
+        foreach ($original as $key => $value) {
+            if (array_key_exists($key, $response)) {
+                if ($response[$key] != $value) {
+                    $this->{$key} = $value;
+                    $updateRecord = true;
+                }
+            } elseif (!array_key_exists($key, $response)) {
+                $this->{$key} = $value;
+                $updateRecord = true;
+            }
+        }
+        
+        if ($updateRecord) {
+            return parent::update();
+        }
+        
+        return true;
+    }
+    
+    /**
+     * Adds userId that a new Memo should go to
+     *
+     * @param integer $userId
+     *
+     * @throws NotSupportedException Only available on new Memo
+     */
+    public function addAssignedUserId($userId)
+    {
+        if ($this->getPrimaryKey()) {
+            throw new NotSupportedException('Adding recipient User only available on new Memo');
+        }
+        
+        $this->assignedUserIds[] = $userId;
+    }
+    
+    /**
+     * Adds Location/companyId that a new Memo should go to
+     *
+     * @param integer $companyId
+     *
+     * @throws NotSupportedException Only available on new Memo
+     */
+    public function addAssignedCompanyId($companyId)
+    {
+        if ($this->getPrimaryKey()) {
+            throw new NotSupportedException('Adding recipient Company only available on new Memo');
+        }
+        
+        $this->assignedCompanyIds[] = $companyId;
     }
 }

--- a/tests/Adapter/MockClient.php
+++ b/tests/Adapter/MockClient.php
@@ -31,7 +31,13 @@ class MockClient implements ClientInterface
     const COUNTRY_INVALID = 9999;
 
     const EMPLOYEE_FIRST = 987235;
-
+    
+    const MEMO_FIRST = 432;
+    
+    const MEMO_SECOND = 321;
+    
+    const MEMO_NEW = 5432;
+    
     const PORTFOLIO_FIRST = 213;
 
     const ROSTER_FIRST = 9283;
@@ -799,7 +805,136 @@ class MockClient implements ClientInterface
         }
         throw new InvalidCallException('Unexpected payload: ' . var_export($payload, true));
     }
-
+    
+    /**
+     * Returns response to GET /resource/Memo/:Id endpoint.
+     *
+     * @param integer $id Memo id
+     *
+     * @return array
+     *
+     * @throws InvalidCallException When id is unknown
+     */
+    protected function getResourceMemo($id)
+    {
+        switch (strtolower($id)) {
+            case 'info':
+                return [
+                    'fields'=> [
+                        'Id' => 'Integer',
+                        'ShowFrom' => 'Date',
+                        'Active' => 'Bit',
+                        'ShowTill' => 'Date',
+                        'Title' => 'VarChar',
+                        'Content' => 'Blob',
+                        'Type' => 'Integer',
+                        'File' => 'Integer',
+                        'Url' => 'VarChar',
+                        'ConfirmText' => 'VarChar',
+                        'Keyword' => 'Blob',
+                        'Creator' => 'Integer',
+                        'Created' => 'DateTime',
+                        'Modified' => 'DateTime',
+                    ],
+                    'joins'=> [],
+                    'assocs'=> [
+                        'Company' => 'Company',
+                        'Role' => 'EmployeeRole',
+                        'Team' => 'Team',
+                    ],
+                    'count'=> 0,
+                ];
+            case static::MEMO_FIRST:
+                return [
+                    'Id' => $id,
+                    'ShowFrom' => '2018-07-31T00:00:00+09:30',
+                    'Active' => true,
+                    'ShowTill' => null,
+                    'Title' => null,
+                    'Content' => 'First Memo Content',
+                    'Type' => 1,
+                    'File' => null,
+                    'Url' => null,
+                    'ConfirmText' => '',
+                    'Keyword' => 'First Memo Content',
+                    'Creator' => static::USER_ADMIN,
+                    'Created' => '2018-07-31T14:36:34+09:30',
+                    'Modified' => '2018-07-31T14:36:34+09:30',
+                ];
+            case static::MEMO_NEW:
+                return [
+                    'Id' => $id,
+                    'ShowFrom' => '2018-08-01T00:00:00+09:30',
+                    'Active' => true,
+                    'ShowTill' => null,
+                    'Title' => null,
+                    'Content' => 'New Memo Content',
+                    'Type' => 1,
+                    'File' => null,
+                    'Url' => null,
+                    'ConfirmText' => '',
+                    'Keyword' => 'New Memo Content',
+                    'Creator' => static::USER_ADMIN,
+                    'Created' => '2018-08-01T14:36:34+09:30',
+                    'Modified' => '2018-08-01T14:36:34+09:30',
+                ];
+        }
+        throw new InvalidCallException('Unknown memo id ' . $id);
+    }
+    
+    /**
+     * Returns response from POST /resource/Memo/:Id endpoint.
+     *
+     * @param integer $id Memo id
+     * @param array $payload POST data
+     *
+     * @return array
+     *
+     * @throws InvalidCallException When id is unknown
+     */
+    protected function postResourceMemo($id, $payload)
+    {
+        switch ($id) {
+            case static::MEMO_FIRST:
+            case static::MEMO_NEW:
+                $memo = $this->getResourceMemo($id);
+                $content = isset($payload['Content']) ? $payload['Content'] : null;
+                if ($content) {
+                    $memo = array_merge(
+                        $memo,
+                        [
+                            'Content' => $content,
+                        ]
+                    );
+                }
+                return $memo;
+        }
+        throw new InvalidCallException('Unknown memo id ' . $id);
+    }
+    
+    /**
+     * Returns response from POST /supervise/memo endpoint.
+     *
+     * @param array $payload POST data
+     *
+     * @return array
+     *
+     * @throws InvalidCallException When payload has no Memo content
+     * @throws MockErrorException When payload has no Company recipients
+     */
+    protected function postSuperviseMemo($payload)
+    {
+        $content = isset($payload['strContent']) ? $payload['strContent'] : null;
+        $arrAssignedCompanyIds = isset($payload['arrAssignedCompanyIds']) ? $payload['arrAssignedCompanyIds'] : null;
+        if ($content && count($arrAssignedCompanyIds) >= 1) {
+            return $this->getResourceMemo(static::MEMO_NEW);
+        } else {
+            throw new MockErrorException('Manually triggered error', 500);
+        }
+        
+        throw new InvalidCallException('Unexpected empty memo content');
+    }
+    
     /**
      * Returns response from GET /resource/OperationalUnit/:id endpoint.
      *

--- a/tests/Adapter/MockClient.php
+++ b/tests/Adapter/MockClient.php
@@ -883,33 +883,16 @@ class MockClient implements ClientInterface
     }
     
     /**
-     * Returns response from POST /resource/Memo/:Id endpoint.
+     * Returns response from POST /resource/Memo/:Id endpoint - not supported
      *
      * @param integer $id Memo id
      * @param array $payload POST data
      *
-     * @return array
-     *
-     * @throws InvalidCallException When id is unknown
+     * @throws DeputyException When attempting to update a Memo - not supported
      */
     protected function postResourceMemo($id, $payload)
     {
-        switch ($id) {
-            case static::MEMO_FIRST:
-            case static::MEMO_NEW:
-                $memo = $this->getResourceMemo($id);
-                $content = isset($payload['Content']) ? $payload['Content'] : null;
-                if ($content) {
-                    $memo = array_merge(
-                        $memo,
-                        [
-                            'Content' => $content,
-                        ]
-                    );
-                }
-                return $memo;
-        }
-        throw new InvalidCallException('Unknown memo id ' . $id);
+        throw new DeputyException('Resource not allowed for modification', 404);
     }
     
     /**

--- a/tests/Model/MemoTest.php
+++ b/tests/Model/MemoTest.php
@@ -35,17 +35,11 @@ class MemoTest extends TestCase
         $memo = $this->wrapper()->createMemo();
         $this->assertFalse($memo->save());
     }
-
-    public function testUpdate()
-    {
-        $memoContent = 'content of the memo message';
-        
-        $memo = $this->wrapper()->getMemo(MockClient::MEMO_FIRST);
-        $memo->content = $memoContent;
-        $this->assertTrue($memo->isAttributeDirty('content'));
-        $this->assertTrue($memo->save());
     
-        $this->assertFalse($memo->isAttributeDirty('content'));
+    public function testUpdateNotSupported()
+    {
+        $memo = $this->wrapper()->getMemo(MockClient::MEMO_FIRST);
+        $this->assertFalse($memo->save(), 'Expected updating of Memo to NOT be available / not supported by Deputy API');
 
         $this->assertRequestLog(
             [

--- a/tests/Model/MemoTest.php
+++ b/tests/Model/MemoTest.php
@@ -30,10 +30,18 @@ class MemoTest extends TestCase
         );
     }
 
-    public function testCreateFail()
+    public function testCreateFailNoRecipients()
     {
         $memo = $this->wrapper()->createMemo();
         $this->assertFalse($memo->save());
+    }
+
+    public function testCreateFailNoContent()
+    {
+        $memo = $this->wrapper()->createMemo();
+        $memo->addAssignedUserId(MockClient::EMPLOYEE_FIRST);
+        $this->assertTrue($memo->save());   // Returns success, however...
+        $this->assertNull($memo->id);       // id is null
     }
     
     public function testUpdateNotSupported()

--- a/tests/Model/MemoTest.php
+++ b/tests/Model/MemoTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace CommunityDS\Deputy\Api\Tests\Model;
+
+use CommunityDS\Deputy\Api\Tests\Adapter\MockClient;
+use CommunityDS\Deputy\Api\Tests\TestCase;
+
+class MemoTest extends TestCase
+{
+
+    public function testCreate()
+    {
+        $memoContent = 'content of the memo message';
+        
+        $memo = $this->wrapper()->createMemo();
+        $memo->addAssignedUserId(MockClient::EMPLOYEE_FIRST);
+        $memo->addAssignedCompanyId(MockClient::COMPANY_FIRST);
+        $memo->content = $memoContent;
+        $this->assertTrue($memo->isAttributeDirty('content'));
+        $this->assertTrue($memo->save());
+        
+        $this->assertEquals(MockClient::MEMO_NEW, $memo->id);
+        $this->assertFalse($memo->isAttributeDirty('content'));
+
+        $this->assertRequestLog(
+            [
+                ['get' => 'resource/Memo/INFO'],
+                ['post' => 'supervise/memo'],
+            ]
+        );
+    }
+
+    public function testCreateFail()
+    {
+        $memo = $this->wrapper()->createMemo();
+        $this->assertFalse($memo->save());
+    }
+
+    public function testUpdate()
+    {
+        $memoContent = 'content of the memo message';
+        
+        $memo = $this->wrapper()->getMemo(MockClient::MEMO_FIRST);
+        $memo->content = $memoContent;
+        $this->assertTrue($memo->isAttributeDirty('content'));
+        $this->assertTrue($memo->save());
+    
+        $this->assertFalse($memo->isAttributeDirty('content'));
+
+        $this->assertRequestLog(
+            [
+                ['get' => 'resource/Memo/INFO'],
+                ['get' => 'resource/Memo/' . MockClient::MEMO_FIRST],
+                ['post' => 'resource/Memo/' . MockClient::MEMO_FIRST],
+            ]
+        );
+    }
+}


### PR DESCRIPTION
Memo recipients can be Users and/or Companies (aka Locations). At least one recipient is required. Recipients can only be assigned on new Memos.
