### PR TITLE
Update supervise/roster payload to default to current instance values

### DIFF
--- a/src/Model/Roster.php
+++ b/src/Model/Roster.php
@@ -109,7 +109,7 @@ class Roster extends Record
             $this->updatePayload($attributeNames)
         );
     }
-
+    
     /**
      * Sends a payload to the POST /supervise/roster endpoint
      * and then sends remaining payload to POST /resource/Roster/:id endpoint.
@@ -124,6 +124,14 @@ class Roster extends Record
         $payload = [];
         if ($this->getPrimaryKey()) {
             $payload['intRosterId'] = $this->getPrimaryKey();
+            /*
+             * Default to the current instance values
+             * otherwise, API would give error of "Date must be given." and/or remove the Employee or Comment
+             */
+            $payload['intStartTimestamp']   = $this->getSchema()->fieldDataType('startTime')->toApi($this->startTime);
+            $payload['intEndTimestamp']     = $this->getSchema()->fieldDataType('endTime')->toApi($this->endTime);
+            $payload['intRosterEmployee']   = $this->getSchema()->fieldDataType('employee')->toApi($this->employee);
+            $payload['strComment']          = $this->getSchema()->fieldDataType('comment')->toApi($this->comment);
         } else {
             $payload['intRosterEmployee'] = 0;
             $payload['blnPublish'] = false;

--- a/src/Model/Roster.php
+++ b/src/Model/Roster.php
@@ -109,7 +109,7 @@ class Roster extends Record
             $this->updatePayload($attributeNames)
         );
     }
-    
+
     /**
      * Sends a payload to the POST /supervise/roster endpoint
      * and then sends remaining payload to POST /resource/Roster/:id endpoint.

--- a/tests/Model/RosterTest.php
+++ b/tests/Model/RosterTest.php
@@ -123,4 +123,34 @@ class RosterTest extends TestCase
         $roster->mealbreakMinutes = 60;
         $this->assertEquals(60, $roster->mealbreakMinutes);
     }
+    
+    public function testUpdateCommentOnly()
+    {
+        $roster = $this->wrapper()->getRoster(MockClient::ROSTER_FIRST);
+        $beforeSaveValues = [
+            'startTime' => $roster->startTime,
+            'endTime' => $roster->endTime,
+            'employee' => $roster->employee,
+        ];
+        $roster->comment = 'Testing Comments';
+        $this->assertTrue($roster->isAttributeDirty('comment'));
+        $this->assertTrue($roster->save());
+        
+        $this->assertEquals('Testing Comments', $roster->comment);
+        $this->assertFalse($roster->isAttributeDirty('comment'));
+        
+        // Testing these values have not changed
+        $this->assertEquals($beforeSaveValues['startTime'], $roster->startTime);
+        $this->assertEquals($beforeSaveValues['endTime'], $roster->endTime);
+        $this->assertEquals($beforeSaveValues['employee'], $roster->employee);
+        
+        $this->assertRequestLog(
+            [
+                ['get' => 'resource/Roster/INFO'],
+                ['get' => 'resource/Roster/' . MockClient::ROSTER_FIRST],
+                ['post' => 'supervise/roster'],
+                ['post' => 'resource/Roster/' . MockClient::ROSTER_FIRST],
+            ]
+        );
+    }
 }


### PR DESCRIPTION
Without these values set in the payload the supervise/roster API call either:
- returns the error "Date must be given" when intStartTimestamp or intEndTimestamp are not part of the payload;
- or, employee or comment values are unset by the API if not explicitly provided in the payload. 